### PR TITLE
GUACAMOLE-2050: USB Device Redirection.

### DIFF
--- a/guacamole-common-js/src/main/webapp/modules/Client.js
+++ b/guacamole-common-js/src/main/webapp/modules/Client.js
@@ -684,6 +684,84 @@ Guacamole.Client = function(tunnel) {
     };
 
     /**
+     * Notifies the server that a USB device has been connected and is 
+     * available for use.
+     *
+     * @param {!string} deviceId
+     *     The unique identifier for the USB device.
+     * 
+     * @param {!number} vendorId
+     *     The vendor ID of the USB device.
+     * 
+     * @param {!number} productId  
+     *     The product ID of the USB device.
+     *
+     * @param {!string} deviceName
+     *     The human-readable name of the device.
+     *
+     * @param {!string} serialNumber
+     *     The serial number of the device.
+     *
+     * @param {!number} deviceClass
+     *     The USB device class.
+     *
+     * @param {!number} deviceSubclass
+     *     The USB device subclass.
+     *
+     * @param {!number} deviceProtocol
+     *     The USB device protocol.
+     *
+     * @param {!string} interfaceData
+     *     Encoded string containing interface and endpoint information.
+     */
+    this.sendUSBConnect = function(deviceId, vendorId, productId, deviceName, 
+            serialNumber, deviceClass, deviceSubclass, deviceProtocol, 
+            interfaceData) {
+        if (!isConnected())
+            return;
+        
+        tunnel.sendMessage("usbconnect", deviceId, vendorId, productId, 
+                deviceName, serialNumber, deviceClass, deviceSubclass, 
+                deviceProtocol, interfaceData);
+    };
+
+    /**
+     * Sends USB data from a Web USB connected device to the server.
+     *
+     * @param {!string} deviceId
+     *     The unique identifier for the USB device.
+     * 
+     * @param {!number} endpoint
+     *     The endpoint number this data originated from on the USB device.
+     *
+     * @param {!string} data
+     *     The base64-encoded data received from the USB device.
+     *
+     * @param {!string} type
+     *     The transfer type (bulk, interrupt, isochronous, control).
+     */
+    this.sendUSBData = function(deviceId, endpoint, data, type) {
+        if (!isConnected())
+            return;
+        
+        tunnel.sendMessage("usbdata", deviceId, endpoint, data, type);
+    };
+
+    /**
+     * Notifies the server that a USB device has been disconnected and is
+     * no longer available.
+     *
+     * @param {!string} deviceId
+     *     The unique identifier for the USB device that was disconnected.
+     */
+    this.sendUSBDisconnect = function(deviceId) {
+        if (!isConnected())
+            return;
+            
+        tunnel.sendMessage("usbdisconnect", deviceId);
+    };
+
+    /**
      * Fired whenever the state of this Guacamole.Client changes.
      * 
      * @event
@@ -929,6 +1007,30 @@ Guacamole.Client = function(tunnel) {
      *     frames.
      */
     this.onsync = null;
+
+    /**
+     * Fired when the server requests USB device disconnection.
+     *
+     * @event
+     * @param {!string} deviceId
+     *     The unique identifier of the USB device to disconnect.
+     */
+    this.onusbdisconnect = null;
+
+    /**
+     * Fired when the server sends USB data to a specific device endpoint.
+     *
+     * @event
+     * @param {!string} deviceId
+     *     The unique identifier of the USB device.
+     *
+     * @param {!number} endpointNumber
+     *     The endpoint number the data is intended for.
+     *
+     * @param {!string} data
+     *     The base64-encoded USB data.
+     */
+    this.onusbdata = null;
 
     /**
      * Returns the layer with the given index, creating it if necessary.
@@ -1733,6 +1835,24 @@ Guacamole.Client = function(tunnel) {
             if (object && object.onundefine)
                 object.onundefine();
 
+        },
+
+        "usbdata": function(parameters) {
+            var deviceId = parameters[0];
+            var endpointNumber = parseInt(parameters[1]);
+            var data = parameters[2];
+            
+            // Forward to the right USB device with endpoint information
+            if (guac_client.onusbdata)
+                guac_client.onusbdata(deviceId, endpointNumber, data);
+        },
+
+        "usbdisconnect": function(parameters) {
+            var deviceId = parameters[0];
+            
+            // Notify client of USB disconnection
+            if (guac_client.onusbdisconnect)
+                guac_client.onusbdisconnect(deviceId);
         },
 
         "video": function(parameters) {

--- a/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
+++ b/guacamole-ext/src/main/resources/org/apache/guacamole/protocols/rdp.json
@@ -268,6 +268,11 @@
                 {
                     "name"  : "static-channels",
                     "type"  : "TEXT"
+                },
+                {
+                    "name"    : "enable-usb",
+                    "type"    : "BOOLEAN",
+                    "options" : [ "true" ]
                 }
             ]
         },

--- a/guacamole/src/main/frontend/src/app/client/templates/client.html
+++ b/guacamole/src/main/frontend/src/app/client/templates/client.html
@@ -110,11 +110,21 @@
                 </div>
 
                 <!-- Devices -->
-                <div class="menu-section" id="devices" ng-if="focusedClient.filesystems.length">
+                <div class="menu-section" id="devices" ng-if="focusedClient">
                     <h3>{{'CLIENT.SECTION_HEADER_DEVICES' | translate}}</h3>
                     <div class="content">
-                        <div class="device filesystem" ng-repeat="filesystem in focusedClient.filesystems" ng-click="showFilesystemMenu(filesystem)">
-                            {{filesystem.name}}
+                        <!-- Filesystems -->
+                        <div ng-if="focusedClient.filesystems.length">
+                            <h4>Filesystems</h4>
+                            <div class="device filesystem" ng-repeat="filesystem in focusedClient.filesystems" ng-click="showFilesystemMenu(filesystem)">
+                                {{filesystem.name}}
+                            </div>
+                            <br>
+                        </div>
+                        
+                        <!-- USB Devices -->
+                        <div>
+                            <guac-usb client="focusedClient"></guac-usb>
                         </div>
                     </div>
                 </div>

--- a/guacamole/src/main/frontend/src/app/client/types/ManagedUSB.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedUSB.js
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides the ManagedUSB class used by ManagedClient to represent
+ * USB devices connected via WebUSB and tunneled to the remote desktop.
+ */
+angular.module('client').factory('ManagedUSB', ['$injector', 
+    function defineManagedUSB($injector) {
+
+    const $q = $injector.get('$q');
+
+    /**
+     * USB connection states.
+     * @readonly
+     * @enum {String}
+     */
+    const ConnectionState = {
+        DISCONNECTED: 'disconnected',
+        CONNECTING: 'connecting',
+        CONNECTED: 'connected',
+        DISCONNECTING: 'disconnecting'
+    };
+
+    /**
+     * Object which represents a USB device connected via WebUSB and
+     * tunneled to a remote connection.
+     * 
+     * @constructor
+     * @param {ManagedUSB|Object} [template={}]
+     *     The object whose properties should be copied within the new
+     *     ManagedUSB.
+     */
+    const ManagedUSB = function ManagedUSB(template) {
+        
+        template = template || {};
+
+        /**
+         * The ManagedClient that owns this USB device.
+         * @type {ManagedClient}
+         */
+        this.client = template.client;
+
+        /**
+         * The WebUSB device object.
+         * @type {USBDevice}
+         */
+        this.device = template.device;
+        
+        /**
+         * Unique identifier for this USB connection session.
+         * @type {String}
+         */
+        this.id = template.id || crypto.randomUUID();
+        
+        /**
+         * Current state of the USB device connection.
+         * @type {String}
+         */
+        this.state = template.state || ConnectionState.DISCONNECTED;
+        
+        /**
+         * Array of IN endpoint information for polling.
+         * Each entry contains {number, type, packetSize}.
+         * @type {Array}
+         */
+        this.inEndpoints = [];
+        
+        /**
+         * Flag indicating whether polling is currently active.
+         * @type {Boolean}
+         */
+        this.pollingActive = false;
+    };
+
+    /**
+     * Creates a new ManagedUSB instance from the given WebUSB device for
+     * the given client.
+     *
+     * @param {ManagedClient} client
+     *     The client that this USB device should be associated with.
+     *
+     * @param {USBDevice} device
+     *     The WebUSB device to use.
+     *
+     * @returns {ManagedUSB}
+     *     The newly-created ManagedUSB.
+     */
+    ManagedUSB.getInstance = function getInstance(client, device) {
+        return new ManagedUSB({ client, device });
+    };
+
+    /**
+     * Collects device information including interfaces and endpoints.
+     * Claims all interfaces and builds endpoint data for polling.
+     * 
+     * @returns {Promise<String>}
+     *     Promise that resolves with formatted interface data string.
+     */
+    ManagedUSB.prototype.collectDeviceInfo = function collectDeviceInfo() {
+        
+        const config = this.device.configuration;
+        
+        // Return empty string if no configuration available
+        if (!config?.interfaces)
+            return Promise.resolve("");
+
+        // Attempt to claim all interfaces
+        const claimPromises = config.interfaces.map(iface => 
+            this.device.claimInterface(iface.interfaceNumber)
+                .then(() => iface)
+                .catch(() => null) // Return null for interfaces we can't claim
+        );
+
+        return Promise.all(claimPromises).then(interfaces => {
+            
+            // Filter out failed interface claims
+            const claimed = interfaces.filter(Boolean);
+            
+            // Clear and rebuild IN endpoints list
+            this.inEndpoints = [];
+            
+            // Build interface data string for protocol
+            const interfaceData = claimed.map(iface => {
+                
+                const alt = iface.alternates[0];
+                
+                // Skip if no alternates available
+                if (!alt)
+                    return '';
+                
+                // Collect IN endpoints with their properties for polling
+                alt.endpoints.forEach(ep => {
+                    if (ep.direction === 'in') {
+                        this.inEndpoints.push({
+                            number: ep.endpointNumber,
+                            type: ep.type,
+                            packetSize: ep.packetSize || 64
+                        });
+                    }
+                });
+                
+                // Format endpoints as string
+                const endpoints = alt.endpoints.map(ep => 
+                    `${ep.endpointNumber}:${ep.direction}:${ep.type}:${ep.packetSize}`
+                ).join(';');
+                
+                // Return formatted interface string
+                return `${iface.interfaceNumber}:${alt.interfaceClass}:${alt.interfaceSubclass}:${alt.interfaceProtocol}:${endpoints}`;
+                
+            }).filter(Boolean).join(',');
+            
+            return interfaceData;
+        });
+    };
+
+    /**
+     * Initiates connecting the USB device to the remote connection.
+     *
+     * @returns {Promise<ManagedUSB>}
+     *     A promise that resolves when the device is connected, or rejects if
+     *     an error occurs.
+     */
+    ManagedUSB.prototype.connect = function connect() {
+        
+        // Cannot connect if not disconnected
+        if (this.state !== ConnectionState.DISCONNECTED)
+            return $q.reject(new Error(`Cannot connect from state: ${this.state}`));
+        
+        this.state = ConnectionState.CONNECTING;
+        const self = this;
+        
+        // Open device and collect information
+        return this.device.open()
+            .then(() => self.collectDeviceInfo())
+            .then(interfaceData => {
+                
+                // Send connection info to server
+                self.client.client.sendUSBConnect(
+                    self.id,
+                    self.device.vendorId,
+                    self.device.productId,
+                    self.device.productName || '',
+                    self.device.serialNumber || '',
+                    self.device.deviceClass,
+                    self.device.deviceSubclass,
+                    self.device.deviceProtocol,
+                    interfaceData
+                );
+                
+                // Mark as connected and start polling
+                self.state = ConnectionState.CONNECTED;
+                self.startPolling();
+                
+                return self;
+            })
+            .catch(error => {
+                
+                // Reset state and cleanup on error
+                self.state = ConnectionState.DISCONNECTED;
+                self.cleanup();
+                throw error;
+                
+            });
+    };
+
+    /**
+     * Starts polling all IN endpoints concurrently for incoming data from the 
+     * USB to be sent to the server.
+     */
+    ManagedUSB.prototype.startPolling = function startPolling() {
+        
+        // Don't start if no endpoints or already polling
+        if (this.inEndpoints.length === 0 || this.pollingActive)
+            return;
+        
+        this.pollingActive = true;
+        const self = this;
+        
+        // Start a separate polling loop for each IN endpoint
+        this.inEndpoints.forEach(endpoint => {
+            self.pollEndpoint(endpoint);
+        });
+    };
+    
+    /**
+     * Polls a single endpoint continuously for incoming data.
+     * 
+     * @param {Object} endpointInfo
+     *     The endpoint information object containing 
+     *     {number, type, and packetSize}.
+     */
+    ManagedUSB.prototype.pollEndpoint = function pollEndpoint(endpointInfo) {
+        
+        const self = this;
+        
+        // Set polling intervals based on endpoint type
+        const baseInterval = endpointInfo.type === 'interrupt' ? 1 : 10;
+        const errorInterval = baseInterval * 10;
+        
+        function poll() {
+            
+            // Stop polling if disconnected or polling disabled
+            if (!self.pollingActive || self.state !== ConnectionState.CONNECTED)
+                return;
+            
+            // Attempt to read from endpoint
+            self.device.transferIn(endpointInfo.number, endpointInfo.packetSize)
+                .then(result => {
+                    
+                    // Send data to server if received
+                    if (result.data?.byteLength > 0)
+                        self.sendDataToServer(endpointInfo, result.data);
+                    
+                    // Continue polling with base interval
+                    if (self.pollingActive)
+                        setTimeout(poll, baseInterval);
+                    
+                })
+                .catch(() => {
+                    
+                    // On error, wait longer before retry
+                    if (self.pollingActive)
+                        setTimeout(poll, errorInterval);
+                    
+                });
+        }
+        
+        // Start polling this endpoint
+        poll();
+    };
+
+    /**
+     * Sends data from a USB device endpoint to the remote connection.
+     *
+     * @param {Object} endpointInfo
+     *     The endpoint information object containing 
+     *     {number, type, and packetSize}.
+     *
+     * @param {ArrayBuffer} data
+     *     The data to send to the remote connection.
+     */
+    ManagedUSB.prototype.sendDataToServer = function sendDataToServer(
+            endpointInfo, data) {
+        
+        // Don't send if not connected
+        if (this.state !== ConnectionState.CONNECTED)
+            return;
+        
+        try {
+            
+            // Convert to base64 and send to server
+            const base64 = this.arrayBufferToBase64(data);
+            this.client.client.sendUSBData(this.id, endpointInfo.number, base64, 
+                    endpointInfo.type);
+            
+        } catch (error) {
+            console.error("Failed to send USB data:", error);
+        }
+    };
+
+    /**
+     * Handles data received from the remote connection.
+     *
+     * @param {String} deviceId
+     *     The device ID this data is intended for.
+     *
+     * @param {Number} endpoint
+     *     The target endpoint number for this data.
+     *
+     * @param {String} data
+     *     The base64-encoded data received from the remote connection.
+     */
+    ManagedUSB.prototype.handleRemoteData = function handleRemoteData(
+            deviceId, endpoint, data) {
+        
+        // Ignore if not connected or wrong device
+        if (this.state !== ConnectionState.CONNECTED || deviceId !== this.id)
+            return;
+        
+        try {
+            
+            // Decode and send to USB device
+            const arrayBuffer = this.base64ToArrayBuffer(data);
+            
+            // Send to endpoint, let WebUSB handle validation
+            this.device.transferOut(endpoint, arrayBuffer)
+                .catch(error => {
+                    console.error(
+                            `USB transfer failed for endpoint ${endpoint}:`, error);
+                });
+                
+        } catch (error) {
+            console.error("Failed to process remote data:", error);
+        }
+    };
+
+    /**
+     * Stops all endpoint polling loops.
+     */
+    ManagedUSB.prototype.stopPolling = function stopPolling() {
+        
+        // Set flag - polling loops will stop themselves when they check it
+        this.pollingActive = false;
+        
+    };
+
+    /**
+     * Disconnects the USB device from this client.
+     *
+     * @returns {Promise}
+     *     A promise that resolves when the device is disconnected.
+     */
+    ManagedUSB.prototype.disconnect = function disconnect() {
+        
+        // Already disconnected
+        if (this.state === ConnectionState.DISCONNECTED)
+            return $q.resolve();
+        
+        this.state = ConnectionState.DISCONNECTING;
+        
+        // Notify server of disconnection
+        if (this.client?.client)
+            this.client.client.sendUSBDisconnect(this.id);
+        
+        // Stop polling and cleanup
+        this.stopPolling();
+        
+        return this.cleanup().then(() => {
+            this.state = ConnectionState.DISCONNECTED;
+        });
+    };
+
+    /**
+     * Cleans up local USB device resources.
+     *
+     * @returns {Promise}
+     *     A promise that resolves when cleanup is complete.
+     */
+    ManagedUSB.prototype.cleanup = function cleanup() {
+        
+        // Stop any active polling
+        this.stopPolling();
+        
+        // Close device if open
+        if (this.device?.opened)
+            return this.device.close().catch(() => {});
+            
+        return $q.resolve();
+    };
+
+    /**
+     * Converts an ArrayBuffer to a base64-encoded string.
+     *
+     * @param {ArrayBuffer} buffer
+     *     The buffer to encode.
+     *
+     * @returns {String}
+     *     The base64-encoded string.
+     */
+    ManagedUSB.prototype.arrayBufferToBase64 = function arrayBufferToBase64(buffer) {
+        
+        const bytes = new Uint8Array(buffer);
+        let binary = '';
+        
+        for (let i = 0; i < bytes.length; i++)
+            binary += String.fromCharCode(bytes[i]);
+            
+        return btoa(binary);
+    };
+
+    /**
+     * Converts a base64-encoded string to an ArrayBuffer.
+     *
+     * @param {String} base64
+     *     The base64 string to decode.
+     *
+     * @returns {ArrayBuffer}
+     *     The decoded ArrayBuffer.
+     */
+    ManagedUSB.prototype.base64ToArrayBuffer = function base64ToArrayBuffer(base64) {
+        
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        
+        for (let i = 0; i < binary.length; i++)
+            bytes[i] = binary.charCodeAt(i);
+            
+        return bytes.buffer;
+    };
+
+    return ManagedUSB;
+    
+}]);

--- a/guacamole/src/main/frontend/src/app/usb/controllers/usbController.js
+++ b/guacamole/src/main/frontend/src/app/usb/controllers/usbController.js
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+angular.module('usb').controller('usbController', ['$scope', '$injector', '$window',
+    function usbController($scope, $injector, $window) {
+        
+        // Required services
+        const usbService = $injector.get('usbService');
+        
+        // Check if WebUSB is supported
+        $scope.webUsbSupported = !!navigator.usb;
+        
+        // Currently available devices
+        $scope.availableDevices = [];
+
+        /**
+         * Request a new USB device
+         */
+        $scope.requestDevice = function requestDevice() {
+            
+            const client = $scope.client;
+            if (!client)
+                return;
+            
+            if (!$scope.webUsbSupported) {
+                console.error('WebUSB not supported in this browser');
+                return;
+            }
+            
+            // Use the USB service to request a device
+            usbService.requestDevice()
+                .then(function deviceSelected(device) {
+                    // Check if device is already connected
+                    if (usbService.isDeviceConnected(client, device))
+                        return null;
+                    
+                    return usbService.connectDevice(device, client);
+                })
+                .then(function deviceConnected(managedUSB) {
+                    if (managedUSB)
+                        refreshDeviceList();
+                })
+                .catch(function deviceRequestFailed(error) {
+                    // Handle user cancellation differently
+                    if (error.name === 'NotFoundError')
+                        console.debug('User cancelled device selection');
+                    else
+                        console.error("Failed to connect USB device:", error);
+                });
+        };
+        
+        /**
+         * Disconnect a USB device
+         * 
+         * @param {USBDevice} device
+         *     The device to disconnect
+         */
+        $scope.disconnectDevice = function disconnectDevice(device) {
+            const client = $scope.client;
+            if (!client) {
+                console.error('No client available');
+                return;
+            }
+            
+            usbService.disconnectDevice(device, client)
+                .then(function deviceDisconnected() {
+                    refreshDeviceList();
+                })
+                .catch(function deviceDisconnectFailed(error) {
+                    console.error("Failed to disconnect USB device:", error);
+                });
+        };
+        
+        /**
+         * Refresh the list of connected devices
+         */
+        function refreshDeviceList() {
+            const client = $scope.client;
+            if (!client) {
+                $scope.availableDevices = [];
+                return;
+            }
+            
+            // Get devices from the managed client
+            const connectedDevices = usbService.getConnectedDevices(client);
+            
+            // Update the list of available devices with the device objects
+            $scope.availableDevices = connectedDevices.map(managedUSB => managedUSB.device);
+        }
+
+        // Watch for client changes
+        $scope.$watch('client', function clientChanged(client) {
+            refreshDeviceList();
+        });
+        
+        // Initial refresh
+        refreshDeviceList();
+    }
+]);

--- a/guacamole/src/main/frontend/src/app/usb/directives/guacUsb.js
+++ b/guacamole/src/main/frontend/src/app/usb/directives/guacUsb.js
@@ -17,19 +17,14 @@
  * under the License.
  */
 
-/**
- * The module for code used to connect to a connection or balancing group.
- */
-angular.module('client', [
-    'auth',
-    'clipboard',
-    'element',
-    'history',
-    'navigation',
-    'notification',
-    'osk',
-    'rest',
-    'textInput',
-    'touch',
-    "usb"
-]);
+angular.module('usb').directive('guacUsb', [function guacUsb() {
+    return {
+        restrict: 'E',
+        replace: true,
+        scope: {
+            client: '='
+        },
+        templateUrl: 'app/usb/templates/guacUsb.html',
+        controller: 'usbController'
+    };
+}]);

--- a/guacamole/src/main/frontend/src/app/usb/services/usbService.js
+++ b/guacamole/src/main/frontend/src/app/usb/services/usbService.js
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Service for interacting with USB devices through WebUSB API
+ */
+angular.module('usb').factory('usbService', ['$injector', 
+    function usbService($injector) {
+        
+        const $q = $injector.get('$q');
+        const $rootScope = $injector.get('$rootScope');
+        const ManagedClient = $injector.get('ManagedClient');
+        const service = {};
+        
+        /**
+         * Whether WebUSB is supported in the current browser.
+         * 
+         * @type {Boolean}
+         */
+        service.isWebUSBSupported = !!navigator.usb;
+        
+        /**
+         * Checks if a USB device is already connected to a client.
+         * 
+         * @param {ManagedClient} client
+         *     The client to check.
+         *     
+         * @param {USBDevice} device
+         *     The USB device to check.
+         *
+         * @returns {Boolean}
+         *     true if the device is already connected to the client, false otherwise.
+         */
+        service.isDeviceConnected = function isDeviceConnected(client, device) {
+            if (!client || !client.usbDevices || !device)
+                return false;
+            
+            return client.usbDevices.some(managedUSB => 
+                managedUSB.device && managedUSB.device.serialNumber === device.serialNumber);
+        };
+        
+        /**
+         * Finds a ManagedUSB instance for a device in a client.
+         * 
+         * @param {ManagedClient} client
+         *     The client to search in.
+         *     
+         * @param {USBDevice} device
+         *     The device to find.
+         *     
+         * @returns {ManagedUSB|null}
+         *     The ManagedUSB instance if found, null otherwise.
+         */
+        service.findManagedUSB = function findManagedUSB(client, device) {
+            if (!client || !client.usbDevices || !device)
+                return null;
+            
+            return client.usbDevices.find(managedUSB => 
+                managedUSB.device && managedUSB.device.serialNumber === device.serialNumber);
+        };
+        
+        /**
+         * Request permission to access a specific USB device
+         * 
+         * @param {Object[]} [filters]
+         *     USB device filters to limit selection
+         *     
+         * @returns {Promise.<USBDevice>}
+         *     A promise that resolves with the selected USB device
+         */
+        service.requestDevice = function requestDevice(filters) {
+            const deferred = $q.defer();
+            
+            if (!service.isWebUSBSupported) {
+                deferred.reject(
+                        new Error("WebUSB API is not available in this browser"));
+                return deferred.promise;
+            }
+            
+            navigator.usb.requestDevice({ filters: filters || [] })
+                .then(device => {
+                    deferred.resolve(device);
+                })
+                .catch(error => {
+                    deferred.reject(error);
+                });
+                
+            return deferred.promise;
+        };
+        
+        /**
+         * Connect to a USB device and associate it with a ManagedClient
+         * 
+         * @param {USBDevice} device
+         *     The USB device to connect
+         *     
+         * @param {ManagedClient} managedClient
+         *     The managed client that will use this device
+         *     
+         * @returns {Promise.<ManagedUSB>}
+         *     A promise that resolves with the ManagedUSB instance
+         */
+        service.connectDevice = function connectDevice(
+                device, managedClient) {
+            const deferred = $q.defer();
+            
+            if (!device) {
+                deferred.reject(new Error("No device provided"));
+                return deferred.promise;
+            }
+            
+            if (!managedClient) {
+                deferred.reject(new Error("No client provided"));
+                return deferred.promise;
+            }
+            
+            // Check if device is already connected to this client
+            if (service.isDeviceConnected(managedClient, device)) {
+                const existingUSB = service.findManagedUSB(
+                        managedClient, device);
+                deferred.resolve(existingUSB);
+                return deferred.promise;
+            }
+            
+            // Use ManagedClient's method to connect the device
+            ManagedClient.connectUSBDevice(managedClient, device)
+                .then(managedUSB => {
+                    deferred.resolve(managedUSB);
+                })
+                .catch(error => {
+                    console.error("Failed to connect USB device:", error);
+                    deferred.reject(error);
+                });
+                
+            return deferred.promise;
+        };
+        
+        /**
+         * Disconnect a USB device from a managed client
+         * 
+         * @param {USBDevice} device
+         *     The USB device to disconnect
+         *     
+         * @param {ManagedClient} managedClient
+         *     The managed client the device is connected to
+         *     
+         * @returns {Promise}
+         *     A promise that resolves when the device is disconnected
+         */
+        service.disconnectDevice = function disconnectDevice(
+                device, managedClient) {
+            const deferred = $q.defer();
+            
+            if (!device || !managedClient) {
+                deferred.resolve();
+                return deferred.promise;
+            }
+            
+            // Find the ManagedUSB instance for this device
+            const managedUSB = service.findManagedUSB(managedClient, device);
+            
+            if (!managedUSB) {
+                deferred.resolve();
+                return deferred.promise;
+            }
+            
+            // Use ManagedClient's method to disconnect the device
+            ManagedClient.disconnectUSBDevice(managedClient, managedUSB)
+                .then(() => {
+                    deferred.resolve();
+                })
+                .catch(error => {
+                    console.error("Error disconnecting USB device:", error);
+                    deferred.reject(error);
+                });
+            
+            return deferred.promise;
+        };
+        
+        /**
+         * Get all USB devices connected to a client
+         * 
+         * @param {ManagedClient} managedClient
+         *     The client to get devices for
+         *     
+         * @returns {ManagedUSB[]}
+         *     Array of connected USB devices
+         */
+        service.getConnectedDevices = function getConnectedDevices(managedClient) {
+            if (!managedClient || !managedClient.usbDevices)
+                return [];
+            
+            return managedClient.usbDevices;
+        };
+        
+        return service;
+    }
+]);

--- a/guacamole/src/main/frontend/src/app/usb/styles/usb.css
+++ b/guacamole/src/main/frontend/src/app/usb/styles/usb.css
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+ .usb-management {
+    margin-bottom: 10px;
+}
+
+.usb-management .panel-heading {
+    background-color: #f5f5f5;
+    border-color: #ddd;
+    padding: 10px 15px;
+}
+
+.usb-management .panel-title {
+    margin-top: 0;
+    margin-bottom: 0;
+    font-size: 16px;
+    color: inherit;
+}
+
+.usb-management .list-group {
+    margin-bottom: 10px;
+}
+
+.usb-management .list-group-item {
+    position: relative;
+    display: block;
+    padding: 10px 15px;
+    margin-bottom: -1px;
+    background-color: #fff;
+    border: 1px solid #ddd;
+}
+
+.usb-management .btn-primary {
+    color: #fff;
+    background-color: #337ab7;
+    border-color: #2e6da4;
+}
+
+.usb-management .btn-danger {
+    color: #fff;
+    background-color: #d9534f;
+    border-color: #d43f3a;
+}
+
+.usb-management .alert-warning {
+    color: #8a6d3b;
+    background-color: #fcf8e3;
+    border-color: #faebcc;
+    padding: 15px;
+    margin-bottom: 15px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}

--- a/guacamole/src/main/frontend/src/app/usb/templates/guacUsb.html
+++ b/guacamole/src/main/frontend/src/app/usb/templates/guacUsb.html
@@ -1,0 +1,41 @@
+<div class="usb-management">
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{'USB.SECTION_HEADER_USB_DEVICES' | translate}}</h3>
+        </div>
+        <div class="panel-body">
+            
+            <div ng-if="!webUsbSupported" class="alert alert-warning">
+                {{'USB.INFO_WEBUSB_NOT_SUPPORTED' | translate}}
+            </div>
+
+            <!-- Device list -->
+            <div>
+                <div class="list-group">
+                    <div ng-if="availableDevices.length === 0" class="list-group-item">
+                        <em>{{'USB.INFO_NO_DEVICES' | translate}}</em>
+                    </div>
+                    <div ng-repeat="device in availableDevices" class="list-group-item">
+                        <div class="row">
+                            <div class="col-md-8">
+                                <strong>{{device.productName || 'USB Device'}}</strong>
+                                <div><small>Vendor: {{device.manufacturerName || 'Unknown'}} ({{device.vendorId}})</small></div>
+                                <div><small>Product: {{device.productName || 'Unknown'}} ({{device.productId}})</small></div>
+                                <div><small>Serial: {{device.serialNumber}}</small></div>
+                            </div>
+                            <div class="col-md-4 text-right">
+                                <button class="btn btn-sm btn-danger" ng-click="disconnectDevice(device)">
+                                    <span class="glyphicon glyphicon-eject"></span> {{'USB.ACTION_DISCONNECT_DEVICE' | translate}}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <button class="btn btn-primary" ng-click="requestDevice()" ng-disabled="!webUsbSupported">
+                    <span class="glyphicon glyphicon-plus"></span> {{'USB.ACTION_CONNECT_DEVICE' | translate}}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/guacamole/src/main/frontend/src/app/usb/usbModule.js
+++ b/guacamole/src/main/frontend/src/app/usb/usbModule.js
@@ -18,18 +18,6 @@
  */
 
 /**
- * The module for code used to connect to a connection or balancing group.
+ * The module for code used to manage USB devices through WebUSB.
  */
-angular.module('client', [
-    'auth',
-    'clipboard',
-    'element',
-    'history',
-    'navigation',
-    'notification',
-    'osk',
-    'rest',
-    'textInput',
-    'touch',
-    "usb"
-]);
+angular.module('usb', []);

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -603,6 +603,7 @@
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Enable audio input (microphone):",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Enable desktop composition (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Enable drive:",
+        "FIELD_HEADER_ENABLE_USB"                 : "Enable USB Redirection:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Enable font smoothing (ClearType):",
         "FIELD_HEADER_ENABLE_FULL_WINDOW_DRAG"    : "Enable full-window drag:",
         "FIELD_HEADER_ENABLE_MENU_ANIMATIONS"     : "Enable menu animations:",
@@ -1236,6 +1237,14 @@
         "ACTION_NAVIGATE_HOME"      : "@:APP.ACTION_NAVIGATE_HOME",
         "ACTION_VIEW_HISTORY"       : "@:APP.ACTION_VIEW_HISTORY"
 
+    },
+
+    "USB" : {
+        "ACTION_CONNECT_DEVICE"      : "Connect USB Device",
+        "ACTION_DISCONNECT_DEVICE"   : "Disconnect",
+        "INFO_WEBUSB_NOT_SUPPORTED"  : "WebUSB is not supported in this browser.",
+        "INFO_NO_DEVICES"            : "No USB devices connected.",
+        "SECTION_HEADER_USB_DEVICES" : "USB Devices"
     }
 
 }


### PR DESCRIPTION
This PR adds Web USB API integration to the Guacamole client, enabling users to redirect local USB devices from their browser to remote desktop sessions through the Guacamole protocol.

Each USB device connection creates a `ManagedUSB` instance that manages the entire lifecycle of that specific device. This handles opening, claiming interfaces, polling endpoints for data, and disconnecting. These are registered with the `ManagedClient`.

## Data Flow

1) User connects a USB device via Web USB API
2) `ManagedUSB` instance is created and added to `ManagedClient.usbDevices`
3) Device interfaces are claimed and endpoint polling begins
4) Incoming USB data is base64-encoded and sent via `usbdata` messages
5) Server responses are decoded and written to appropriate USB endpoints
6) Disconnection can be initiated from either client or server side

## New proposed protocol messages

### client → server
* `usbconnect`: Sent when a USB device is connected, includes device ID, vendor/product IDs, device metadata, and flattened interface/endpoint descriptors
* `usbdata`: Streams data from USB device endpoints to the server with endpoint number and transfer type
* `usbdisconnect`: Notifies server when a USB device is disconnected locally

### server → client
* `usbdata`: Receives data from the server to write to specific USB device endpoints
* `usbdisconnect`: Server-initiated disconnection requests for specific devices